### PR TITLE
Fix bug with filenames that contain dots

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -9,7 +9,7 @@ class Helpers {
     if (base.substr(-3) === '.md') {
       base = base.substr(0, base.length - 3)
     }
-    return base.replace(/([^a-z0-9\-_~]+)/gi, '')
+    return base.replace(/([^a-z0-9\-_~.]+)/gi, '')
   }
 
 }


### PR DESCRIPTION
Filenames that contain dots (for example `1.1-test.md`) were successfully inventoried in the TOC, but the files weren't added to the documentation. This was due to the different mechanisms of generating IDs - the alias is extracted from the filename, while this helper function also filters out values, including dots. If the values don't match, the file is not added to the output.

If there are similiar bugs in the future, this should be the point to look at.