### PR TITLE
Fix for issue #20

### DIFF
--- a/src/html-writer.js
+++ b/src/html-writer.js
@@ -61,7 +61,7 @@ class HtmlWriter extends BaseWriter {
       <div class="row">
         <div class="col-md-3">
           <div class="nav-container">
-            <div class="nav-inner" id="scroll-spy">
+            <div class="nav-inner" id="scroll-spy" style="overflow-y: auto; height: 90%;">
               <span class="toc"></span>
               ${this.converter.getToc().getHtml()}
               ${this.getFooter()}

--- a/src/html-writer.js
+++ b/src/html-writer.js
@@ -61,7 +61,7 @@ class HtmlWriter extends BaseWriter {
       <div class="row">
         <div class="col-md-3">
           <div class="nav-container">
-            <div class="nav-inner" id="scroll-spy" style="overflow-y: auto; height: 90%;">
+            <div class="nav-inner" id="scroll-spy" style="overflow-y: auto; top: 0; bottom: 0;">
               <span class="toc"></span>
               ${this.converter.getToc().getHtml()}
               ${this.getFooter()}


### PR DESCRIPTION
TOCs with more content than the window can fit weren't scrollable, so items farther down were left inaccessible.

Added a scrollbar and defined a height for the TOC container so it knows when scrolling is necessary. Hardcoded at 90% height because I couldn't figure out how to have the container's height detected automatically.