### PR TITLE
Fix replacing spaces with dashes in the page name

### DIFF
--- a/src/markdown.js
+++ b/src/markdown.js
@@ -152,7 +152,7 @@ class Markdown {
       }
 
       // make sure page name has correct format
-      link = pageName.replace(" ", "-")
+      pageName = pageName.replace(/ /g, "-")
 
       // convert [[<link title> | <page name>]] to [<link title>](<page name>)
       link = `[${linkTitle}](${pageName})`


### PR DESCRIPTION
There was already some code for detecting internal wiki links and hooking them up correctly, but there was a bug that was breaking adding dashes to the page name.  This fixes #23.