### PR TITLE
Preserve links to /uploads/

### DIFF
--- a/src/markdown.js
+++ b/src/markdown.js
@@ -35,7 +35,8 @@ class Markdown {
     }
 
     this.mainRenderer.link = function(href, title, text) {
-      if (!href.match(/^https?:\/\//) || self.isTocLink(href)) {
+      if (!(href.match(/^https?:\/\//) || href.match(/^\/uploads\//)) ||
+          self.isTocLink(href)) {
         href = '#' + helpers.getPageIdFromFilenameOrLink(href)
       }
       return `<a href="${href}">${text}</a>`


### PR DESCRIPTION
I did this to make links to `/uploads/` work in a converted Gitlab wiki.  It seems that `/uploads/` is where Gitlab wiki stores uploaded files, and gwtc was breaking those links.  I _doubt this hack is the right general solution_.  Any suggestions for a better one?