### PR TITLE
Case insensitive searching .md files

### DIFF
--- a/dist/finder.js
+++ b/dist/finder.js
@@ -39,6 +39,7 @@ var Finder = (function () {
 
         dir.readFiles(wikiPath, dirOpts, function (err, content, filename, next) {
           if (!err) {
+            filename = filename.toLowerCase();
             mdFiles[filename] = content;
             var base = path.basename(filename);
             aliases[base.substr(0, base.length - 3)] = filename;


### PR DESCRIPTION
Now links to .md files from TOC will be case-insensitive, so link to myFile will be also looking for myfile.md in filesystem.
